### PR TITLE
Fixed Fabric Crash and Added support and extract checks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -116,3 +116,10 @@ run/
 
 # Avoid ignoring Gradle wrapper jar file (.jar files are usually ignored)
 !gradle-wrapper.jar
+
+# Visual Studio Code
+.settings/
+.vscode/
+bin/
+.classpath
+.project

--- a/common/src/main/java/earth/terrarium/botarium/api/energy/EnergyHooks.java
+++ b/common/src/main/java/earth/terrarium/botarium/api/energy/EnergyHooks.java
@@ -83,7 +83,7 @@ public class EnergyHooks {
     /**
      * A safe version of {@link #moveEnergy(PlatformEnergyManager, PlatformEnergyManager, long)} that will not move any energy if the
      * {@link PlatformEnergyManager} is not present.
-     *
+     * <p>
      * Transfers energy from a {@link PlatformEnergyManager} to another {@link PlatformEnergyManager}.
      * @param from The {@link PlatformEnergyManager} to extract energy from.
      * @param to The {@link PlatformEnergyManager} to transfer energy to.

--- a/common/src/main/java/earth/terrarium/botarium/api/energy/ExtractOnlyEnergyContainer.java
+++ b/common/src/main/java/earth/terrarium/botarium/api/energy/ExtractOnlyEnergyContainer.java
@@ -2,7 +2,6 @@ package earth.terrarium.botarium.api.energy;
 
 import earth.terrarium.botarium.api.Updatable;
 import net.minecraft.util.Mth;
-import net.minecraft.world.level.block.entity.BlockEntity;
 
 public class ExtractOnlyEnergyContainer extends SimpleUpdatingEnergyContainer {
     public ExtractOnlyEnergyContainer(Updatable entity, int energyCapacity) {

--- a/common/src/main/java/earth/terrarium/botarium/api/energy/InsertOnlyEnergyContainer.java
+++ b/common/src/main/java/earth/terrarium/botarium/api/energy/InsertOnlyEnergyContainer.java
@@ -2,7 +2,6 @@ package earth.terrarium.botarium.api.energy;
 
 import earth.terrarium.botarium.api.Updatable;
 import net.minecraft.util.Mth;
-import net.minecraft.world.level.block.entity.BlockEntity;
 
 public class InsertOnlyEnergyContainer extends SimpleUpdatingEnergyContainer {
     public InsertOnlyEnergyContainer(Updatable entity, int energyCapacity) {

--- a/common/src/main/java/earth/terrarium/botarium/api/energy/PlatformEnergyManager.java
+++ b/common/src/main/java/earth/terrarium/botarium/api/energy/PlatformEnergyManager.java
@@ -17,7 +17,8 @@ public interface PlatformEnergyManager {
 
     /**
      * Extracts an amount of energy from the manager.
-     * @param amount The amount of energy to extract.
+     *
+     * @param amount   The amount of energy to extract.
      * @param simulate If true, the extraction will only be simulated.
      * @return The amount of energy that was extracted.
      */
@@ -25,9 +26,20 @@ public interface PlatformEnergyManager {
 
     /**
      * Inserts an amount of energy from the manager.
-     * @param amount The amount of energy to insert.
+     *
+     * @param amount   The amount of energy to insert.
      * @param simulate If true, the insertion will only be simulated.
      * @return The amount of energy that was inserted.
      */
     long insert(long amount, boolean simulate);
+
+    /**
+     * @return If the manager supports insertion.
+     */
+    boolean supportsInsertion();
+
+    /**
+     * @return If the manager supports extraction.
+     */
+    boolean supportsExtraction();
 }

--- a/common/src/main/java/earth/terrarium/botarium/api/fluid/FluidHooks.java
+++ b/common/src/main/java/earth/terrarium/botarium/api/fluid/FluidHooks.java
@@ -106,6 +106,7 @@ public class FluidHooks {
      * @return An optional containing the {@link PlatformFluidHandler} if the {@link BlockEntity} is a fluid container, otherwise empty.
      */
     public static Optional<PlatformFluidHandler> safeGetBlockFluidManager(BlockEntity entity, @Nullable Direction direction) {
+        if (entity == null) return Optional.empty();
         return isFluidContainingBlock(entity, direction) ? Optional.of(getBlockFluidManager(entity, direction)) : Optional.empty();
     }
 
@@ -135,7 +136,7 @@ public class FluidHooks {
     /**
      * A safe version of {@link #moveFluid(PlatformFluidHandler, PlatformFluidHandler, FluidHolder)} that will not move any fluid if the
      * {@link PlatformFluidHandler} is not present.
-     *
+     * <p>
      * Transfers fluid from a {@link PlatformFluidHandler} to another {@link PlatformFluidHandler}.
      * @param from The {@link PlatformFluidHandler} to extract fluid from.
      * @param to The {@link PlatformFluidHandler} to transfer fluid to.

--- a/common/src/main/java/earth/terrarium/botarium/api/fluid/PlatformFluidHandler.java
+++ b/common/src/main/java/earth/terrarium/botarium/api/fluid/PlatformFluidHandler.java
@@ -1,8 +1,22 @@
 package earth.terrarium.botarium.api.fluid;
 
 public interface PlatformFluidHandler {
+
     long insertFluid(FluidHolder fluid, boolean simulate);
+
     FluidHolder extractFluid(FluidHolder fluid, boolean simulate);
+
     int getTankAmount();
+
     FluidHolder getFluidInTank(int tank);
+
+    /**
+     * @return If the handler supports insertion.
+     */
+    boolean supportsInsertion();
+
+    /**
+     * @return If the handler supports extraction.
+     */
+    boolean supportsExtraction();
 }

--- a/common/src/main/java/earth/terrarium/botarium/api/fluid/SimpleUpdatingFluidContainer.java
+++ b/common/src/main/java/earth/terrarium/botarium/api/fluid/SimpleUpdatingFluidContainer.java
@@ -12,7 +12,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.function.BiPredicate;
 import java.util.function.Function;
-import java.util.function.IntPredicate;
 
 @Deprecated
 public class SimpleUpdatingFluidContainer implements UpdatingFluidContainer {

--- a/common/src/test/java/testmod/ExampleN2SPipeBlockEntity.java
+++ b/common/src/test/java/testmod/ExampleN2SPipeBlockEntity.java
@@ -1,0 +1,30 @@
+package testmod;
+
+import earth.terrarium.botarium.api.fluid.FluidHooks;
+import earth.terrarium.botarium.api.fluid.PlatformFluidHandler;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.state.BlockState;
+
+public class ExampleN2SPipeBlockEntity extends ExampleBlockEntity {
+
+    public ExampleN2SPipeBlockEntity(BlockPos blockPos, BlockState blockState) {
+        super(TestMod.EXAMPLE_PIPE_BLOCK_ENTITY.get(), blockPos, blockState);
+    }
+
+    @Override
+    public void tick() {
+        if (!this.getLevel().isClientSide) {
+            BlockEntity forwardBlock = level.getBlockEntity(getBlockPos().north());
+            BlockEntity backBlock = level.getBlockEntity(getBlockPos().south());
+
+            PlatformFluidHandler forwardTank = FluidHooks.safeGetBlockFluidManager(forwardBlock, Direction.NORTH).orElse(null);
+            PlatformFluidHandler backTank = FluidHooks.safeGetBlockFluidManager(backBlock, Direction.SOUTH).orElse(null);
+
+            if (forwardTank != null && backTank != null && !forwardTank.getFluidInTank(0).isEmpty()) {
+                FluidHooks.moveFluid(forwardTank, backTank, forwardTank.getFluidInTank(0));
+            }
+        }
+    }
+}

--- a/common/src/test/java/testmod/ExamplePipe.java
+++ b/common/src/test/java/testmod/ExamplePipe.java
@@ -1,0 +1,21 @@
+package testmod;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.state.BlockState;
+import org.jetbrains.annotations.Nullable;
+
+import javax.annotation.ParametersAreNonnullByDefault;
+
+@ParametersAreNonnullByDefault
+public class ExamplePipe extends ExampleBlock {
+    public ExamplePipe(Properties properties) {
+        super(properties);
+    }
+
+    @Nullable
+    @Override
+    public BlockEntity newBlockEntity(BlockPos blockPos, BlockState blockState) {
+        return new ExampleN2SPipeBlockEntity(blockPos, blockState);
+    }
+}

--- a/fabric/src/main/java/earth/terrarium/botarium/fabric/energy/FabricEnergyManager.java
+++ b/fabric/src/main/java/earth/terrarium/botarium/fabric/energy/FabricEnergyManager.java
@@ -51,4 +51,14 @@ public class FabricEnergyManager implements PlatformEnergyManager {
             return insert;
         }
     }
+
+    @Override
+    public boolean supportsInsertion() {
+        return energy.supportsInsertion();
+    }
+
+    @Override
+    public boolean supportsExtraction() {
+        return energy.supportsExtraction();
+    }
 }

--- a/fabric/src/main/java/earth/terrarium/botarium/fabric/extensions/FluidManagerImpl.java
+++ b/fabric/src/main/java/earth/terrarium/botarium/fabric/extensions/FluidManagerImpl.java
@@ -14,9 +14,7 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.material.Fluid;
 import net.msrandom.extensions.annotations.ClassExtension;
-import net.msrandom.extensions.annotations.ImplementedByExtension;
 import net.msrandom.extensions.annotations.ImplementsBaseElement;
-import org.apache.commons.lang3.NotImplementedException;
 import org.jetbrains.annotations.Nullable;
 
 @ClassExtension(FluidHooks.class)

--- a/fabric/src/main/java/earth/terrarium/botarium/fabric/extensions/MenuHooksExtensions.java
+++ b/fabric/src/main/java/earth/terrarium/botarium/fabric/extensions/MenuHooksExtensions.java
@@ -5,9 +5,7 @@ import earth.terrarium.botarium.api.menu.MenuHooks;
 import earth.terrarium.botarium.fabric.menu.ExtraDataMenuProviderWrapper;
 import net.minecraft.server.level.ServerPlayer;
 import net.msrandom.extensions.annotations.ClassExtension;
-import net.msrandom.extensions.annotations.ImplementedByExtension;
 import net.msrandom.extensions.annotations.ImplementsBaseElement;
-import org.apache.commons.lang3.NotImplementedException;
 
 @ClassExtension(MenuHooks.class)
 public class MenuHooksExtensions {

--- a/fabric/src/main/java/earth/terrarium/botarium/fabric/extensions/RegistryHelpersImpl.java
+++ b/fabric/src/main/java/earth/terrarium/botarium/fabric/extensions/RegistryHelpersImpl.java
@@ -10,7 +10,6 @@ import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.msrandom.extensions.annotations.ClassExtension;
 import net.msrandom.extensions.annotations.ImplementsBaseElement;
-import org.spongepowered.asm.mixin.Overwrite;
 
 @ClassExtension(RegistryHelpers.class)
 public class RegistryHelpersImpl {

--- a/fabric/src/main/java/earth/terrarium/botarium/fabric/fluid/FabricFluidHandler.java
+++ b/fabric/src/main/java/earth/terrarium/botarium/fabric/fluid/FabricFluidHandler.java
@@ -38,7 +38,7 @@ public class FabricFluidHandler implements PlatformFluidHandler {
             if (!simulate) {
                 transaction.commit();
             }
-            return extracted == 0 ? FabricFluidHolder.of(fabricFluidHolder.toVariant(), extracted) : FabricFluidHolder.EMPTY;
+            return extracted == 0 ? FabricFluidHolder.of(fabricFluidHolder.toVariant(), extracted) : fluid;
         }
     }
 
@@ -56,5 +56,15 @@ public class FabricFluidHandler implements PlatformFluidHandler {
         List<FluidHolder> fluids = new ArrayList<>();
         storage.iterator().forEachRemaining(variant -> fluids.add(FabricFluidHolder.of(variant.getResource(), variant.getAmount())));
         return fluids.get(tank);
+    }
+
+    @Override
+    public boolean supportsInsertion() {
+        return insertFluid(getFluidInTank(0), true) > 0;
+    }
+
+    @Override
+    public boolean supportsExtraction() {
+        return extractFluid(getFluidInTank(0), true).getFluidAmount() > 0;
     }
 }

--- a/fabric/src/main/java/earth/terrarium/botarium/fabric/fluid/FabricFluidHolder.java
+++ b/fabric/src/main/java/earth/terrarium/botarium/fabric/fluid/FabricFluidHolder.java
@@ -14,7 +14,7 @@ import net.minecraft.world.level.material.Fluids;
 
 @SuppressWarnings("UnstableApiUsage")
 public class FabricFluidHolder extends SnapshotParticipant<FabricFluidHolder> implements FluidHolder, StorageView<FluidVariant> {
-    public static FabricFluidHolder EMPTY = FabricFluidHolder.of(Fluids.EMPTY, null, 0);
+    public static final FabricFluidHolder EMPTY = FabricFluidHolder.of(Fluids.EMPTY, null, 0);
     private FluidVariant fluidVariant;
     private long amount;
 

--- a/fabric/src/main/java/earth/terrarium/botarium/fabric/fluid/WrappedFluidHolder.java
+++ b/fabric/src/main/java/earth/terrarium/botarium/fabric/fluid/WrappedFluidHolder.java
@@ -3,10 +3,8 @@ package earth.terrarium.botarium.fabric.fluid;
 import earth.terrarium.botarium.api.fluid.FluidHolder;
 import net.fabricmc.fabric.api.transfer.v1.fluid.FluidVariant;
 import net.fabricmc.fabric.api.transfer.v1.storage.StorageView;
-import net.fabricmc.fabric.api.transfer.v1.transaction.Transaction;
 import net.fabricmc.fabric.api.transfer.v1.transaction.TransactionContext;
 import net.fabricmc.fabric.api.transfer.v1.transaction.base.SnapshotParticipant;
-import net.minecraft.util.Mth;
 import org.jetbrains.annotations.Nullable;
 
 @SuppressWarnings("UnstableApiUsage")

--- a/forge/src/main/java/earth/terrarium/botarium/forge/BotariumForge.java
+++ b/forge/src/main/java/earth/terrarium/botarium/forge/BotariumForge.java
@@ -5,7 +5,6 @@ import earth.terrarium.botarium.api.energy.EnergyBlock;
 import earth.terrarium.botarium.api.energy.EnergyItem;
 import earth.terrarium.botarium.api.fluid.FluidHoldingBlock;
 import earth.terrarium.botarium.api.fluid.FluidHoldingItem;
-import earth.terrarium.botarium.api.fluid.ItemFluidContainer;
 import earth.terrarium.botarium.api.item.ItemContainerBlock;
 import earth.terrarium.botarium.forge.fluid.ForgeFluidContainer;
 import earth.terrarium.botarium.forge.fluid.ForgeItemFluidContainer;

--- a/forge/src/main/java/earth/terrarium/botarium/forge/energy/ForgeEnergyManager.java
+++ b/forge/src/main/java/earth/terrarium/botarium/forge/energy/ForgeEnergyManager.java
@@ -40,4 +40,14 @@ public class ForgeEnergyManager implements PlatformEnergyManager {
     public long insert(long amount, boolean simulate) {
         return energy.receiveEnergy((int) amount, simulate);
     }
+
+    @Override
+    public boolean supportsInsertion() {
+        return energy.canReceive();
+    }
+
+    @Override
+    public boolean supportsExtraction() {
+        return energy.canExtract();
+    }
 }

--- a/forge/src/main/java/earth/terrarium/botarium/forge/extensions/FluidManagerImpl.java
+++ b/forge/src/main/java/earth/terrarium/botarium/forge/extensions/FluidManagerImpl.java
@@ -12,7 +12,6 @@ import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.material.Fluid;
 import net.minecraftforge.common.capabilities.ForgeCapabilities;
 import net.minecraftforge.fluids.FluidType;
-import net.minecraftforge.fluids.capability.wrappers.BlockWrapper;
 import net.msrandom.extensions.annotations.ClassExtension;
 import net.msrandom.extensions.annotations.ImplementsBaseElement;
 import org.jetbrains.annotations.Nullable;

--- a/forge/src/main/java/earth/terrarium/botarium/forge/extensions/MenuHooksExtensions.java
+++ b/forge/src/main/java/earth/terrarium/botarium/forge/extensions/MenuHooksExtensions.java
@@ -6,7 +6,6 @@ import net.minecraft.server.level.ServerPlayer;
 import net.minecraftforge.network.NetworkHooks;
 import net.msrandom.extensions.annotations.ClassExtension;
 import net.msrandom.extensions.annotations.ImplementsBaseElement;
-import org.apache.commons.lang3.NotImplementedException;
 
 @ClassExtension(MenuHooks.class)
 public class MenuHooksExtensions {

--- a/forge/src/main/java/earth/terrarium/botarium/forge/fluid/ForgeFluidHandler.java
+++ b/forge/src/main/java/earth/terrarium/botarium/forge/fluid/ForgeFluidHandler.java
@@ -25,4 +25,14 @@ public record ForgeFluidHandler(IFluidHandler handler) implements PlatformFluidH
     public FluidHolder getFluidInTank(int tank) {
         return new ForgeFluidHolder(handler.getFluidInTank(tank));
     }
+
+    @Override
+    public boolean supportsInsertion() {
+        return insertFluid(getFluidInTank(0), true) > 0;
+    }
+
+    @Override
+    public boolean supportsExtraction() {
+        return extractFluid(getFluidInTank(0), true).getFluidAmount() > 0;
+    }
 }

--- a/forge/src/main/java/earth/terrarium/botarium/forge/fluid/ForgeFluidHolder.java
+++ b/forge/src/main/java/earth/terrarium/botarium/forge/fluid/ForgeFluidHolder.java
@@ -3,7 +3,6 @@ package earth.terrarium.botarium.forge.fluid;
 import earth.terrarium.botarium.api.fluid.FluidHolder;
 import net.minecraft.core.Registry;
 import net.minecraft.nbt.CompoundTag;
-import net.minecraft.nbt.NbtUtils;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.level.material.Fluid;
 import net.minecraft.world.level.material.Fluids;

--- a/forge/src/main/java/earth/terrarium/botarium/forge/fluid/ForgeItemFluidContainer.java
+++ b/forge/src/main/java/earth/terrarium/botarium/forge/fluid/ForgeItemFluidContainer.java
@@ -6,7 +6,6 @@ import earth.terrarium.botarium.api.fluid.FluidHolder;
 import earth.terrarium.botarium.api.fluid.ItemFluidContainer;
 import earth.terrarium.botarium.forge.AutoSerializable;
 import net.minecraft.core.Direction;
-import net.minecraft.nbt.CompoundTag;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.ItemStack;
 import net.minecraftforge.common.capabilities.Capability;


### PR DESCRIPTION
- Fixes FluidHooks.moveFluid() crashing on Fabric, due to FabricFluidHandler.extractFluid() returning a blank fluid variant.
- Added supportsInsertion() and supportsExtraction() methods to the PlatformFluidHandler and PlatformEnergyManager.
- Added a pipe test block for testing fluid transfer.
- Cleaned imports.