### PR TITLE
Fix FabricFluidContainer return wrong capacity

### DIFF
--- a/common/src/test/java/testmod/TestItem.java
+++ b/common/src/test/java/testmod/TestItem.java
@@ -42,11 +42,13 @@ public class TestItem extends Item implements EnergyItem, FluidHoldingItem {
     public void appendHoverText(ItemStack stack, @Nullable Level level, List<Component> tooltip, TooltipFlag tooltipFlag) {
         PlatformFluidItemHandler itemFluidManager = FluidHooks.getItemFluidManager(stack);
         long oxygen = itemFluidManager.getFluidInTank(0).getFluidAmount();
-        tooltip.add(Component.literal("Water: " + oxygen + "mb").setStyle(Style.EMPTY.withColor(ChatFormatting.GRAY)));
+        long oxygenCapacity = itemFluidManager.getTankCapacity(0);
+        tooltip.add(Component.literal("Water: " + oxygen + "mb / "+ oxygenCapacity + "mb").setStyle(Style.EMPTY.withColor(ChatFormatting.GRAY)));
 
         PlatformItemEnergyManager energyManager = EnergyHooks.getItemEnergyManager(stack);
         long energy = energyManager.getStoredEnergy();
-        tooltip.add(Component.literal("Energy: " + energy + "FE").setStyle(Style.EMPTY.withColor(ChatFormatting.GRAY)));
+        long energyCapacity = energyManager.getCapacity();
+        tooltip.add(Component.literal("Energy: " + energy + "FE / "+ energyCapacity + "FE").setStyle(Style.EMPTY.withColor(ChatFormatting.GRAY)));
     }
 
     /*

--- a/fabric/src/main/java/earth/terrarium/botarium/fabric/fluid/FabricBlockFluidContainer.java
+++ b/fabric/src/main/java/earth/terrarium/botarium/fabric/fluid/FabricBlockFluidContainer.java
@@ -1,5 +1,6 @@
 package earth.terrarium.botarium.fabric.fluid;
 
+import earth.terrarium.botarium.api.fluid.FluidHolder;
 import earth.terrarium.botarium.api.fluid.FluidSnapshot;
 import earth.terrarium.botarium.api.fluid.UpdatingFluidContainer;
 import net.fabricmc.fabric.api.transfer.v1.fluid.FluidVariant;
@@ -9,6 +10,8 @@ import net.fabricmc.fabric.api.transfer.v1.transaction.TransactionContext;
 import net.minecraft.world.level.block.entity.BlockEntity;
 
 import java.util.Iterator;
+import java.util.List;
+import java.util.stream.IntStream;
 
 @SuppressWarnings("UnstableApiUsage")
 public class FabricBlockFluidContainer extends ExtendedFluidContainer implements Storage<FluidVariant>, ManualSyncing {
@@ -34,7 +37,8 @@ public class FabricBlockFluidContainer extends ExtendedFluidContainer implements
 
     @Override
     public Iterator<StorageView<FluidVariant>> iterator() {
-        return container.getFluids().stream().map(holder -> new WrappedFluidHolder(this, holder, container::extractFromSlot)).map(holder -> (StorageView<FluidVariant>) holder).iterator();
+        List<FluidHolder> fluids = container.getFluids();
+        return IntStream.range(0, fluids.size()).mapToObj(index -> new WrappedFluidHolder(this, fluids.get(index), container::extractFromSlot, container.getTankCapacity(index))).map(holder -> (StorageView<FluidVariant>) holder).iterator();
     }
 
     @Override

--- a/fabric/src/main/java/earth/terrarium/botarium/fabric/fluid/FabricItemFluidContainer.java
+++ b/fabric/src/main/java/earth/terrarium/botarium/fabric/fluid/FabricItemFluidContainer.java
@@ -2,6 +2,7 @@ package earth.terrarium.botarium.fabric.fluid;
 
 import earth.terrarium.botarium.Botarium;
 import earth.terrarium.botarium.api.fluid.FluidContainer;
+import earth.terrarium.botarium.api.fluid.FluidHolder;
 import earth.terrarium.botarium.api.fluid.FluidSnapshot;
 import net.fabricmc.fabric.api.transfer.v1.context.ContainerItemContext;
 import net.fabricmc.fabric.api.transfer.v1.fluid.FluidVariant;
@@ -13,6 +14,8 @@ import net.minecraft.nbt.CompoundTag;
 import net.minecraft.world.item.ItemStack;
 
 import java.util.Iterator;
+import java.util.List;
+import java.util.stream.IntStream;
 
 @SuppressWarnings("UnstableApiUsage")
 public class FabricItemFluidContainer extends ExtendedFluidContainer implements Storage<FluidVariant>, ManualSyncing {
@@ -44,7 +47,8 @@ public class FabricItemFluidContainer extends ExtendedFluidContainer implements 
 
     @Override
     public Iterator<StorageView<FluidVariant>> iterator() {
-        return container.getFluids().stream().map(holder -> new WrappedFluidHolder(this, holder, container::extractFromSlot)).map(holder -> (StorageView<FluidVariant>) holder).iterator();
+        List<FluidHolder> fluids = container.getFluids();
+        return IntStream.range(0, fluids.size()).mapToObj(index -> new WrappedFluidHolder(this, fluids.get(index), container::extractFromSlot, container.getTankCapacity(index))).map(holder -> (StorageView<FluidVariant>) holder).iterator();
     }
 
     @Override

--- a/fabric/src/main/java/earth/terrarium/botarium/fabric/fluid/WrappedFluidHolder.java
+++ b/fabric/src/main/java/earth/terrarium/botarium/fabric/fluid/WrappedFluidHolder.java
@@ -12,11 +12,13 @@ public class WrappedFluidHolder extends ExtendedFluidContainer implements Storag
     private FluidHolder fluidHolder;
     private final FluidExtraction extraction;
     private final ExtendedFluidContainer container;
+    private final long capacity;
 
-    public WrappedFluidHolder(ExtendedFluidContainer container, FluidHolder fluidHolder, FluidExtraction extraction) {
+    public WrappedFluidHolder(ExtendedFluidContainer container, FluidHolder fluidHolder, FluidExtraction extraction, long capacity) {
         this.fluidHolder = fluidHolder;
         this.extraction = extraction;
         this.container = container;
+        this.capacity = capacity;
     }
 
     public FluidVariant fluidVariant() {
@@ -45,7 +47,7 @@ public class WrappedFluidHolder extends ExtendedFluidContainer implements Storag
 
     @Override
     public long getCapacity() {
-        return Integer.MAX_VALUE;
+        return this.capacity;
     }
 
     @Override


### PR DESCRIPTION
Below screenshots showing how to different PlatformFluidItemHandler.getTankCapacity's return value.

## Previous

![image](https://user-images.githubusercontent.com/44163945/205489444-255bdfc0-5e81-4608-abc8-6331d0ecb095.png)

## Fixed

![image](https://user-images.githubusercontent.com/44163945/205489447-3c903d89-09f3-484c-a5b8-1368c796bc19.png)
