### PR TITLE
Add fluid translation methods

### DIFF
--- a/common/src/main/java/earth/terrarium/botarium/api/fluid/FluidHolder.java
+++ b/common/src/main/java/earth/terrarium/botarium/api/fluid/FluidHolder.java
@@ -4,6 +4,7 @@ import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import net.minecraft.core.Registry;
 import net.minecraft.nbt.CompoundTag;
+import net.minecraft.network.chat.Component;
 import net.minecraft.world.level.material.Fluid;
 
 import java.util.Optional;
@@ -80,4 +81,8 @@ public interface FluidHolder {
      * @param tag The {@link CompoundTag} to deserialize from.
      */
     void deserialize(CompoundTag tag);
+
+    Component getTranslationName();
+
+    String getTranslationKey();
 }

--- a/common/src/test/java/testmod/TestItem.java
+++ b/common/src/test/java/testmod/TestItem.java
@@ -41,9 +41,11 @@ public class TestItem extends Item implements EnergyItem, FluidHoldingItem {
     @Override
     public void appendHoverText(ItemStack stack, @Nullable Level level, List<Component> tooltip, TooltipFlag tooltipFlag) {
         PlatformFluidItemHandler itemFluidManager = FluidHooks.getItemFluidManager(stack);
-        long oxygen = itemFluidManager.getFluidInTank(0).getFluidAmount();
-        long oxygenCapacity = itemFluidManager.getTankCapacity(0);
-        tooltip.add(Component.literal("Water: " + oxygen + "mb / "+ oxygenCapacity + "mb").setStyle(Style.EMPTY.withColor(ChatFormatting.GRAY)));
+        FluidHolder fluidInTank = itemFluidManager.getFluidInTank(0);
+        Component fluidName = fluidInTank.getTranslationName();
+        long fluidAmount = fluidInTank.getFluidAmount();
+        long fluidCapacity = itemFluidManager.getTankCapacity(0);
+        tooltip.add(Component.translatable("Fluid: %s: %s mb / %s mb", fluidName, fluidAmount, fluidCapacity).setStyle(Style.EMPTY.withColor(ChatFormatting.GRAY)));
 
         PlatformItemEnergyManager energyManager = EnergyHooks.getItemEnergyManager(stack);
         long energy = energyManager.getStoredEnergy();

--- a/fabric/src/main/java/earth/terrarium/botarium/fabric/fluid/FabricFluidHolder.java
+++ b/fabric/src/main/java/earth/terrarium/botarium/fabric/fluid/FabricFluidHolder.java
@@ -2,11 +2,13 @@ package earth.terrarium.botarium.fabric.fluid;
 
 import earth.terrarium.botarium.api.fluid.FluidHolder;
 import net.fabricmc.fabric.api.transfer.v1.fluid.FluidVariant;
+import net.fabricmc.fabric.api.transfer.v1.fluid.FluidVariantAttributes;
 import net.fabricmc.fabric.api.transfer.v1.storage.StorageView;
 import net.fabricmc.fabric.api.transfer.v1.transaction.TransactionContext;
 import net.fabricmc.fabric.api.transfer.v1.transaction.base.SnapshotParticipant;
 import net.minecraft.core.Registry;
 import net.minecraft.nbt.CompoundTag;
+import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.util.Mth;
 import net.minecraft.world.level.material.Fluid;
@@ -144,6 +146,16 @@ public class FabricFluidHolder extends SnapshotParticipant<FabricFluidHolder> im
     protected void readSnapshot(FabricFluidHolder snapshot) {
         this.fluidVariant = FluidVariant.of(snapshot.getFluid(), snapshot.getCompound());
         this.setAmount(snapshot.getFluidAmount());
+    }
+
+    @Override
+    public Component getTranslationName() {
+        return FluidVariantAttributes.getName(this.fluidVariant);
+    }
+
+    @Override
+    public String getTranslationKey() {
+        return this.getFluid().defaultFluidState().createLegacyBlock().getBlock().getDescriptionId();
     }
 
     public static FabricFluidHolder empty() {

--- a/forge/src/main/java/earth/terrarium/botarium/forge/fluid/ForgeFluidHolder.java
+++ b/forge/src/main/java/earth/terrarium/botarium/forge/fluid/ForgeFluidHolder.java
@@ -3,6 +3,7 @@ package earth.terrarium.botarium.forge.fluid;
 import earth.terrarium.botarium.api.fluid.FluidHolder;
 import net.minecraft.core.Registry;
 import net.minecraft.nbt.CompoundTag;
+import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.level.material.Fluid;
 import net.minecraft.world.level.material.Fluids;
@@ -101,6 +102,16 @@ public class ForgeFluidHolder implements FluidHolder {
     @Override
     public boolean isEmpty() {
         return fluidStack.isEmpty();
+    }
+
+    @Override
+    public Component getTranslationName() {
+        return this.fluidStack.getDisplayName();
+    }
+
+    @Override
+    public String getTranslationKey() {
+        return this.fluidStack.getTranslationKey();
     }
 
     public static FluidStack toStack(FluidHolder holder) {


### PR DESCRIPTION
## Summary

For solve  Ad-Astra!'s issue (https://github.com/terrarium-earth/Ad-Astra/issues/89)

That issue's reason is Immersive Engineering  is not following block description id on fluid name translation.
But It's not really problem in `Forge`, Because `'FluidStack'` is supporting get translated name.

So, Botarium also need provide get fluid translated name from `'FluidHolder'` for cross platform in my think.

## Changeds

Add 2 methods at FluidHolder and each platform is implements them.
1. getTranslationName() Component
2. getTanslationKey() String

## Demo

### Forge

![image](https://user-images.githubusercontent.com/44163945/209285182-e9acbd93-e73b-488b-bb31-f76086981946.png)

![image](https://user-images.githubusercontent.com/44163945/209285969-23ef3db0-791e-4665-82e4-74b211f27d72.png)

### Fabric

![image](https://user-images.githubusercontent.com/44163945/209285200-0e43ab2e-1e84-4ba2-86e1-369238f2287b.png)

![image](https://user-images.githubusercontent.com/44163945/209285206-f2837680-4106-49fa-aadf-602d3cc58232.png)
