### PR TITLE
Add QOL methods to FluidHolder

### DIFF
--- a/common/src/main/java/earth/terrarium/botarium/common/fluid/base/FluidHolder.java
+++ b/common/src/main/java/earth/terrarium/botarium/common/fluid/base/FluidHolder.java
@@ -3,11 +3,14 @@ package earth.terrarium.botarium.common.fluid.base;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import earth.terrarium.botarium.common.fluid.utils.FluidHooks;
+import net.minecraft.core.Holder;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.nbt.CompoundTag;
+import net.minecraft.tags.TagKey;
 import net.minecraft.world.level.material.Fluid;
 
 import java.util.Optional;
+import java.util.function.Predicate;
 
 /**
  * An object that holds a fluid with an amount and a tag.
@@ -106,4 +109,27 @@ public interface FluidHolder {
         if (!copy.isEmpty()) copy.setAmount(amount);
         return copy;
     }
+
+    @SuppressWarnings("deprecation")
+    default Holder<Fluid> getFluidHolder() {
+        return getFluid().builtInRegistryHolder();
+    }
+
+    @SuppressWarnings("deprecation")
+    default boolean is(TagKey<Fluid> tagKey) {
+        return getFluid().is(tagKey);
+    }
+
+    default boolean is(Fluid fluid) {
+        return getFluid() == fluid;
+    }
+
+    default boolean is(Predicate<Holder<Fluid>> predicate) {
+        return predicate.test(getFluidHolder());
+    }
+
+    default boolean is(Holder<Fluid> fluid) {
+        return getFluidHolder() == fluid;
+    }
+
 }

--- a/common/src/main/java/earth/terrarium/botarium/common/fluid/utils/ClientFluidHooks.java
+++ b/common/src/main/java/earth/terrarium/botarium/common/fluid/utils/ClientFluidHooks.java
@@ -2,6 +2,7 @@ package earth.terrarium.botarium.common.fluid.utils;
 
 import earth.terrarium.botarium.common.fluid.base.FluidHolder;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
+import net.minecraft.network.chat.Component;
 import net.msrandom.extensions.annotations.ImplementedByExtension;
 import org.apache.commons.lang3.NotImplementedException;
 
@@ -13,6 +14,11 @@ public class ClientFluidHooks {
 
     @ImplementedByExtension
     public static int getFluidColor(FluidHolder fluid) {
+        throw new NotImplementedException();
+    }
+
+    @ImplementedByExtension
+    public static Component getDisplayName(FluidHolder fluid) {
         throw new NotImplementedException();
     }
 }

--- a/fabric/src/main/java/earth/terrarium/botarium/fabric/extensions/ClientFluidHookImpl.java
+++ b/fabric/src/main/java/earth/terrarium/botarium/fabric/extensions/ClientFluidHookImpl.java
@@ -4,8 +4,11 @@ import earth.terrarium.botarium.common.fluid.base.FluidHolder;
 import earth.terrarium.botarium.common.fluid.utils.ClientFluidHooks;
 import earth.terrarium.botarium.fabric.fluid.holder.FabricFluidHolder;
 import net.fabricmc.fabric.api.transfer.v1.client.fluid.FluidVariantRendering;
+import net.fabricmc.fabric.api.transfer.v1.fluid.FluidVariantAttributes;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
+import net.minecraft.network.chat.Component;
 import net.msrandom.extensions.annotations.ClassExtension;
+import net.msrandom.extensions.annotations.ImplementedByExtension;
 import net.msrandom.extensions.annotations.ImplementsBaseElement;
 
 @SuppressWarnings("UnstableApiUsage")
@@ -20,6 +23,11 @@ public class ClientFluidHookImpl {
     @ImplementsBaseElement
     public static int getFluidColor(FluidHolder fluid) {
         return FluidVariantRendering.getColor(FabricFluidHolder.of(fluid).toVariant());
+    }
+
+    @ImplementedByExtension
+    public static Component getDisplayName(FluidHolder fluid) {
+        return FluidVariantAttributes.getName(FabricFluidHolder.of(fluid).toVariant());
     }
 
 }

--- a/forge/src/main/java/earth/terrarium/botarium/forge/extensions/ClientFluidHooksImpl.java
+++ b/forge/src/main/java/earth/terrarium/botarium/forge/extensions/ClientFluidHooksImpl.java
@@ -17,13 +17,13 @@ public class ClientFluidHooksImpl {
     @ImplementsBaseElement
     public static TextureAtlasSprite getFluidSprite(FluidHolder fluid) {
         IClientFluidTypeExtensions extension = IClientFluidTypeExtensions.of(fluid.getFluid());
-        ResourceLocation resourceLocation = extension.getStillTexture(new ForgeFluidHolder(fluid).getFluidStack());
+        ResourceLocation resourceLocation = extension.getStillTexture(ForgeFluidHolder.toStack(fluid));
         return Minecraft.getInstance().getTextureAtlas(TextureAtlas.LOCATION_BLOCKS).apply(resourceLocation);
     }
 
     @ImplementsBaseElement
     public static int getFluidColor(FluidHolder fluid) {
         IClientFluidTypeExtensions extension = IClientFluidTypeExtensions.of(fluid.getFluid());
-        return extension.getTintColor(new ForgeFluidHolder(fluid).getFluidStack());
+        return extension.getTintColor(ForgeFluidHolder.toStack(fluid));
     }
 }

--- a/forge/src/main/java/earth/terrarium/botarium/forge/extensions/ClientFluidHooksImpl.java
+++ b/forge/src/main/java/earth/terrarium/botarium/forge/extensions/ClientFluidHooksImpl.java
@@ -6,9 +6,11 @@ import earth.terrarium.botarium.forge.fluid.ForgeFluidHolder;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.texture.TextureAtlas;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
+import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraftforge.client.extensions.common.IClientFluidTypeExtensions;
 import net.msrandom.extensions.annotations.ClassExtension;
+import net.msrandom.extensions.annotations.ImplementedByExtension;
 import net.msrandom.extensions.annotations.ImplementsBaseElement;
 
 @ClassExtension(ClientFluidHooks.class)
@@ -25,5 +27,10 @@ public class ClientFluidHooksImpl {
     public static int getFluidColor(FluidHolder fluid) {
         IClientFluidTypeExtensions extension = IClientFluidTypeExtensions.of(fluid.getFluid());
         return extension.getTintColor(new ForgeFluidHolder(fluid).getFluidStack());
+    }
+
+    @ImplementedByExtension
+    public static Component getDisplayName(FluidHolder fluid) {
+        return ForgeFluidHolder.toStack(fluid).getDisplayName();
     }
 }


### PR DESCRIPTION
#### What does this PR change?

This adds a few QOL helper methods to FluidHolder to match ItemStack for doing comparisons with other fluid related things.
This also fixes Forge creating a new fluid holder for no reason