### PR TITLE
Fixed a possible nullptr exception caused by getEnergyContainer returning null on a block that is an energy container.

### DIFF
--- a/common/src/main/java/earth/terrarium/botarium/common/energy/EnergyApi.java
+++ b/common/src/main/java/earth/terrarium/botarium/common/energy/EnergyApi.java
@@ -163,8 +163,8 @@ public class EnergyApi {
         List<EnergyContainer> list = Direction.stream()
                 .map(direction -> Pair.of(direction, level.getBlockEntity(blockPos.relative(direction))))
                 .filter(pair -> pair.getSecond() != null)
-                .filter(pair -> isEnergyBlock(pair.getSecond(), pair.getFirst().getOpposite()))
                 .map(pair -> getBlockEnergyContainer(pair.getSecond(), pair.getFirst()))
+                .filter(energy -> energy != null)
                 .sorted(Comparator.comparingLong(energy -> energy.insertEnergy(amount, true)))
                 .toList();
         int receiverCount = list.size();

--- a/common/src/main/java/earth/terrarium/botarium/common/energy/EnergyApi.java
+++ b/common/src/main/java/earth/terrarium/botarium/common/energy/EnergyApi.java
@@ -3,9 +3,6 @@ package earth.terrarium.botarium.common.energy;
 import com.mojang.datafixers.util.Pair;
 import earth.terrarium.botarium.common.energy.base.BotariumEnergyBlock;
 import earth.terrarium.botarium.common.energy.base.EnergyContainer;
-import earth.terrarium.botarium.common.energy.impl.WrappedBlockEnergyContainer;
-import earth.terrarium.botarium.common.energy.impl.WrappedItemEnergyContainer;
-import earth.terrarium.botarium.common.fluid.FluidApi;
 import earth.terrarium.botarium.common.item.ItemStackHolder;
 import earth.terrarium.botarium.util.Updatable;
 import net.minecraft.core.BlockPos;
@@ -22,10 +19,7 @@ import org.apache.commons.lang3.NotImplementedException;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.function.Supplier;
 
 public class EnergyApi {
@@ -164,7 +158,7 @@ public class EnergyApi {
                 .map(direction -> Pair.of(direction, level.getBlockEntity(blockPos.relative(direction))))
                 .filter(pair -> pair.getSecond() != null)
                 .map(pair -> getBlockEnergyContainer(pair.getSecond(), pair.getFirst()))
-                .filter(energy -> energy != null)
+                .filter(Objects::nonNull)
                 .sorted(Comparator.comparingLong(energy -> energy.insertEnergy(amount, true)))
                 .toList();
         int receiverCount = list.size();


### PR DESCRIPTION
Made a null check after get block energy container instead of checking for block to be an energy container in distributeEnergyNearby.

Problem caused by there being no null check after getting energy: In a mod of mine, when a create: crafts and additions (forge 1.20.1) accumulator is placed adjacent to its generator block, it would crash the game `java.lang.NullPointerException: Cannot invoke "earth.terrarium.botarium.common.energy.base.EnergyContainer.insertEnergy(long, boolean)" because "energy" is null`, there is a possibility that a similar crash could happen with other mods.

Tested:
 - Forge: Nothing appears to be broken and the above issue has been fixed.
 - Fabric: No testing done, however there shouldn't be any issues.

Changes in the commit:
 - replaced checking if a block is an energy block with checking with instead checking if energyContainer is null after it.
 - Some import changes by Intellij IDEA
 
Possible issues that could be caused:
 - none, in both forge and fabric energy container getting function first checks if that block is an energy container.
