### PR TITLE
Fix the BaseFluidIngredient test always returning false

### DIFF
--- a/resources/common/src/main/java/earth/terrarium/common_storage_lib/resources/fluid/ingredient/impl/BaseFluidIngredient.java
+++ b/resources/common/src/main/java/earth/terrarium/common_storage_lib/resources/fluid/ingredient/impl/BaseFluidIngredient.java
@@ -57,7 +57,7 @@ public class BaseFluidIngredient implements FluidIngredient {
 
     @Override
     public boolean test(FluidResource fluidResource) {
-        return false;
+        return this.getMatchingFluids().stream().anyMatch(resource -> resource.isOf(fluidResource.getType()));
     }
 
     @Override


### PR DESCRIPTION
## Issue
Currently it always returns false which messes with other Ingredient matching / testing.

## Changes
* Add actual testing instead of returning false in BaseFluidIngredient#test