### PR TITLE
Fix storage data not saving to item components

### DIFF
--- a/core/common/src/main/java/earth/terrarium/common_storage_lib/fluid/impl/SimpleFluidSlot.java
+++ b/core/common/src/main/java/earth/terrarium/common_storage_lib/fluid/impl/SimpleFluidSlot.java
@@ -108,6 +108,11 @@ public class SimpleFluidSlot implements StorageSlot<FluidResource>, UpdateManage
             this.filter = filter;
         }
 
+        @Deprecated
+        public Filtered(long limit, Runnable update, Predicate<FluidResource> filter) {
+            this(limit, update, () -> {}, filter);
+        }
+
         @Override
         public boolean isResourceValid(FluidResource resource) {
             return filter.test(resource);

--- a/core/common/src/main/java/earth/terrarium/common_storage_lib/fluid/impl/SimpleFluidSlot.java
+++ b/core/common/src/main/java/earth/terrarium/common_storage_lib/fluid/impl/SimpleFluidSlot.java
@@ -103,8 +103,8 @@ public class SimpleFluidSlot implements StorageSlot<FluidResource>, UpdateManage
     public static class Filtered extends SimpleFluidSlot {
         private final Predicate<FluidResource> filter;
 
-        public Filtered(long limit, Runnable update, Predicate<FluidResource> filter) {
-            super(limit, update);
+        public Filtered(long limit, Runnable update, Runnable save, Predicate<FluidResource> filter) {
+            super(limit, update, save);
             this.filter = filter;
         }
 

--- a/core/common/src/main/java/earth/terrarium/common_storage_lib/fluid/impl/SimpleFluidStorage.java
+++ b/core/common/src/main/java/earth/terrarium/common_storage_lib/fluid/impl/SimpleFluidStorage.java
@@ -30,10 +30,10 @@ public class SimpleFluidStorage implements CommonStorage<FluidResource>, UpdateM
     }
 
     public SimpleFluidStorage(ItemContext context, DataComponentType<FluidStorageData> componentType, int size, long limit) {
-        this.slots = NonNullList.withSize(size, new SimpleFluidSlot(limit, this::update));
         this.limit = limit;
         this.update = context::updateAll;
         this.save = () -> context.set(componentType, FluidStorageData.from(this));
+        this.slots = NonNullList.withSize(size, new SimpleFluidSlot(limit, this::update, this.save));
         FluidStorageData data = context.getResource().get(componentType);
         if (data != null) readSnapshot(data);
     }
@@ -50,7 +50,10 @@ public class SimpleFluidStorage implements CommonStorage<FluidResource>, UpdateM
     }
 
     public SimpleFluidStorage filter(int slot, Predicate<FluidResource> predicate) {
-        slots.set(slot, new SimpleFluidSlot.Filtered(limit, this::update, predicate));
+        SimpleFluidSlot oldSlot = slots.get(slot);
+        SimpleFluidSlot newSlot = new SimpleFluidSlot.Filtered(limit, this.update, this.save, predicate);
+        newSlot.readSnapshot(oldSlot.createSnapshot());
+        slots.set(slot, newSlot);
         return this;
     }
 

--- a/core/common/src/main/java/earth/terrarium/common_storage_lib/item/impl/SimpleItemSlot.java
+++ b/core/common/src/main/java/earth/terrarium/common_storage_lib/item/impl/SimpleItemSlot.java
@@ -1,6 +1,7 @@
 package earth.terrarium.common_storage_lib.item.impl;
 
 import earth.terrarium.common_storage_lib.resources.ResourceStack;
+import earth.terrarium.common_storage_lib.resources.fluid.FluidResource;
 import earth.terrarium.common_storage_lib.resources.item.ItemResource;
 import earth.terrarium.common_storage_lib.storage.util.ModifiableItemSlot;
 import earth.terrarium.common_storage_lib.storage.base.StorageSlot;
@@ -149,6 +150,11 @@ public class SimpleItemSlot implements StorageSlot<ItemResource>, ModifiableItem
         public Filtered(Runnable update, Runnable save, Predicate<ItemResource> filter) {
             super(update, save);
             this.filter = filter;
+        }
+
+        @Deprecated
+        public Filtered(Runnable update, Predicate<ItemResource> filter) {
+            this(update, () -> {}, filter);
         }
 
         @Override

--- a/core/common/src/main/java/earth/terrarium/common_storage_lib/item/impl/SimpleItemSlot.java
+++ b/core/common/src/main/java/earth/terrarium/common_storage_lib/item/impl/SimpleItemSlot.java
@@ -146,8 +146,8 @@ public class SimpleItemSlot implements StorageSlot<ItemResource>, ModifiableItem
     public static class Filtered extends SimpleItemSlot {
         private final Predicate<ItemResource> filter;
 
-        public Filtered(Runnable update, Predicate<ItemResource> filter) {
-            super(update);
+        public Filtered(Runnable update, Runnable save, Predicate<ItemResource> filter) {
+            super(update, save);
             this.filter = filter;
         }
 

--- a/core/common/src/main/java/earth/terrarium/common_storage_lib/item/impl/SimpleItemStorage.java
+++ b/core/common/src/main/java/earth/terrarium/common_storage_lib/item/impl/SimpleItemStorage.java
@@ -2,6 +2,7 @@ package earth.terrarium.common_storage_lib.item.impl;
 
 import earth.terrarium.common_storage_lib.context.ItemContext;
 import earth.terrarium.common_storage_lib.data.DataManager;
+import earth.terrarium.common_storage_lib.fluid.impl.SimpleFluidSlot;
 import earth.terrarium.common_storage_lib.resources.item.ItemResource;
 import earth.terrarium.common_storage_lib.item.util.ItemStorageData;
 import earth.terrarium.common_storage_lib.storage.base.CommonStorage;
@@ -25,9 +26,9 @@ public class SimpleItemStorage implements CommonStorage<ItemResource>, UpdateMan
     }
 
     public SimpleItemStorage(ItemContext context, DataComponentType<ItemStorageData> componentType, int size) {
-        this.slots = NonNullList.withSize(size, new SimpleItemSlot(this::update));
         this.onUpdate = context::updateAll;
         this.save = () -> context.set(componentType, ItemStorageData.of(this));
+        this.slots = NonNullList.withSize(size, new SimpleItemSlot(this::update, this.save));
         if (context.getResource().has(componentType)) {
             this.readSnapshot(context.getResource().get(componentType));
         }
@@ -41,7 +42,10 @@ public class SimpleItemStorage implements CommonStorage<ItemResource>, UpdateMan
     }
 
     public SimpleItemStorage filter(int slot, Predicate<ItemResource> predicate) {
-        slots.set(slot, new SimpleItemSlot.Filtered(this::update, predicate));
+        SimpleItemSlot oldSlot = slots.get(slot);
+        SimpleItemSlot newSlot = new SimpleItemSlot.Filtered(this::update, this.save, predicate);
+        newSlot.readSnapshot(oldSlot.createSnapshot());
+        slots.set(slot, newSlot);
         return this;
     }
 

--- a/resources/common/src/main/java/earth/terrarium/common_storage_lib/resources/fluid/FluidResource.java
+++ b/resources/common/src/main/java/earth/terrarium/common_storage_lib/resources/fluid/FluidResource.java
@@ -101,4 +101,19 @@ public final class FluidResource extends ResourceComponent {
     public boolean is(TagKey<Fluid> tag) {
         return type.is(tag);
     }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) return true;
+        if (!(obj instanceof FluidResource other)) return false;
+        if (this.type != other.type) return false;
+        return this.dataPatch.equals(other.dataPatch);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = type.hashCode();
+        result = 31 * result + dataPatch.hashCode();
+        return result;
+    }
 }


### PR DESCRIPTION
## Problems
The `save` runnable in `SimpleFluidStorage` and `SimpleItemStorage` is currently defined after the slot is created but not passed to the slots. This in turn caused any insert/extract to do nothing on save as the default save runnable is `() -> {}`.

The second issue is that currently the `filter()` method replaces slots with filtered versions, discarding any data from the original slot.

The third issue is that currently FluidResource does not implement a working equals check. Meaning when SimpleFluidSlot checks if the resource inside equals the resource to insert, it will fail.

## Changes
* Construct the `save` runnable before slot creation and pass it to the slot
* Modify the `filter` method to preserve slot data when replacing with a filtered slot
* Implement `equals` and `hashCode` in `FluidResource`